### PR TITLE
Fix for the Race Designer complaining about missing graphics

### DIFF
--- a/Common/RaceDefinition/AllRaceIcons.cs
+++ b/Common/RaceDefinition/AllRaceIcons.cs
@@ -81,8 +81,12 @@ namespace Nova.Common
                 {
                     using(Config conf = new Config())
                     {
+                        var graphicFolder = FileSearcher.GetGraphicsPath();
+
+
+
                         // load the icons
-                        DirectoryInfo info = new DirectoryInfo(Path.Combine(conf[Global.GraphicsFolderKey], "Race"));
+                        DirectoryInfo info = new DirectoryInfo(Path.Combine(graphicFolder, "Race"));
                         foreach (FileInfo fi in info.GetFiles())
                         {
                             Bitmap i = new Bitmap(Path.Combine(fi.DirectoryName, fi.Name));

--- a/Nova/WinForms/RaceDesigner/RaceDesigner.cs
+++ b/Nova/WinForms/RaceDesigner/RaceDesigner.cs
@@ -184,7 +184,7 @@ namespace Nova.WinForms.RaceDesigner
             this.iconIndex.Text = Path.GetFileNameWithoutExtension(this.currentRaceIcon.Source);
 
             // Can't trust the windows designer generate code to set the environment range before setting the environment value, so set it here to be sure.
-            this.temperatureTolerance.MinimumValue = 15;
+            this.temperatureTolerance.MinimumValue = 15;            
             this.temperatureTolerance.MaximumValue = 85;
             this.temperatureTolerance.ActivateRangeChange();
 


### PR DESCRIPTION
the config file had not added a graphics folder entry yet. Changed the code to look at the same entry for the component graphics, which creates the missing entry if needed. 